### PR TITLE
 add ops-file for download product from s3 in air-gapped env

### DIFF
--- a/ops-files/update-download-product-s3.yml
+++ b/ops-files/update-download-product-s3.yml
@@ -1,0 +1,3 @@
+- op: replace  
+  path: /jobs/name=create-opsman-and-configure-auth/plan/task=download-product/file
+  value: platform-automation-tasks/tasks/download-product-s3.yml


### PR DESCRIPTION
this is for the situation where concourse need to download product from s3. such as air-gapped env.
it worked to replace pipeline  as following:
```
./1-fly-install-opsman.sh demo pcfdemo install-opsman ops-files/download-product-s3.yml
```
thanks.